### PR TITLE
Make sure build-related directories exist & minor webapp -related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This command will update the `codegen/addresses.ts` file with the deployed contr
 Once the contracts are deployed you can run the frontend by running:
 
 ```sh
-deno dev --open
+deno task dev --open
 ```
 
 This will start a development server with live reload and open your browser to the local url.

--- a/index.html
+++ b/index.html
@@ -7,6 +7,6 @@
     </head>
     <body>
         <div id="root"></div>
-        <script type="module" src="/web/main.tsx"></script>
+        <script type="module" src="src/web/main.tsx"></script>
     </body>
 </html>

--- a/src/tools/build.ts
+++ b/src/tools/build.ts
@@ -4,7 +4,13 @@
 import { compile, SolcOutput, tryResolveImport } from '@parity/revive'
 import solc from 'solc'
 import { format } from 'prettier'
-import { readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+    mkdirSync,
+    readdirSync,
+    readFileSync,
+    unlinkSync,
+    writeFileSync,
+} from 'node:fs'
 import { join, basename } from 'node:path'
 import { Buffer } from 'node:buffer'
 import { parseArgs } from 'node:util'
@@ -89,6 +95,9 @@ for (const file of input) {
     })
 
     const evmOut = JSON.parse(evmCompile(input)) as SolcOutput
+
+    mkdirSync(join(codegenDir, 'abi'), { recursive: true })
+    mkdirSync(join(codegenDir, 'bytecode'), { recursive: true })
 
     for (const [id, contracts] of Object.entries(reviveOut.contracts)) {
         for (const [name, contract] of Object.entries(contracts)) {


### PR DESCRIPTION
This PR is for the following minor changes and fixes:

- Avoid the following build error when the target directory for the build does not exist:

```
error: Uncaught Error: ENOENT: no such file or directory, write
            writeFileSync(
```

- Fix `deno` command in docs to run the web app.
- Fix `src` file path in web app's `<script>`