### PR TITLE
Deploy benchmark report to GitHub Pages on main branch updates

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy benchmark report to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - benchmark/reports/benchmark_report.html
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      # Preserve the previous URL: /benchmark/reports/benchmark_report.html
+      - name: Prepare pages directory
+        run: mkdir -p _site/benchmark/reports && cp benchmark/reports/benchmark_report.html _site/benchmark/reports/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,41 +1,41 @@
 name: Deploy benchmark report to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - benchmark/reports/benchmark_report.html
+    push:
+        branches:
+            - main
+        paths:
+            - benchmark/reports/benchmark_report.html
 
 permissions:
-  pages: write
-  id-token: write
+    pages: write
+    id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+    group: pages
+    cancel-in-progress: false
 
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
+            - name: Setup Pages
+              uses: actions/configure-pages@v5
 
-      # Preserve the previous URL: /benchmark/reports/benchmark_report.html
-      - name: Prepare pages directory
-        run: mkdir -p _site/benchmark/reports && cp benchmark/reports/benchmark_report.html _site/benchmark/reports/
+            # Preserve the previous URL: /benchmark/reports/benchmark_report.html
+            - name: Prepare pages directory
+              run: mkdir -p _site/benchmark/reports && cp benchmark/reports/benchmark_report.html _site/benchmark/reports/
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: _site
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: _site
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
Adds a GitHub Actions workflow to deploy the benchmark HTML report to GitHub Pages whenever `benchmark_report.html` is updated on main.

This replaces the previous branch-based deployment from `mj/add-polkadot-contracts-benchmark`.
The report is available at: https://paritytech.github.io/contracts-boilerplate/benchmark/reports/benchmark_report.html
Same as the previous link.

Note: The repo's GitHub Pages source needs to be changed to GitHub Actions in Settings > Pages.